### PR TITLE
Update to trane v0.14.2 and implement new features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,8 +2001,6 @@ dependencies = [
 [[package]]
 name = "trane"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931f9183e1a91a5456e4229b9a61c6706eff41d027404ef5414d5404c9d1063b"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "trane"
-version = "0.14.1"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d943f6f1bee06e8c2aaf04e1e84803ac242b33ef5eab1f9a9066b408b04a126"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2030,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "trane-cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "trane-cli"
-version = "0.14.1"
+version = "0.14.2"
 build = "build.rs"
 default-run = "trane"
 
@@ -23,10 +23,10 @@ rustyline = "11.0.0"
 rustyline-derive = "0.8.0"
 serde_json = "1.0.93"
 termimad = "0.22.0"
-# trane = "0.14.1"
+trane = "0.14.2"
 ustr = { version = "0.9.0", features = ["serialization"] }
 # Commented out for use in local development.
-trane = { path = "../trane" }
+# trane = { path = "../trane" }
 
 [build-dependencies]
 built = { version = "0.6.0", features = ["chrono", "git2", "semver"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ rustyline = "11.0.0"
 rustyline-derive = "0.8.0"
 serde_json = "1.0.93"
 termimad = "0.22.0"
-trane = "0.14.1"
+# trane = "0.14.1"
 ustr = { version = "0.9.0", features = ["serialization"] }
 # Commented out for use in local development.
-# trane = { path = "../trane" }
+trane = { path = "../trane" }
 
 [build-dependencies]
 built = { version = "0.6.0", features = ["chrono", "git2", "semver"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -956,13 +956,25 @@ impl TraneApp {
     }
 
     /// Removes the given unit from the blacklist.
-    pub fn whitelist(&mut self, unit_id: &Ustr) -> Result<()> {
+    pub fn remove_from_blacklist(&mut self, unit_id: &Ustr) -> Result<()> {
         ensure!(self.trane.is_some(), "no Trane instance is open");
 
         self.trane
             .as_mut()
             .unwrap()
             .remove_from_blacklist(unit_id)?;
+        self.reset_batch();
+        Ok(())
+    }
+
+    /// Removes the given unit from the blacklist.
+    pub fn remove_prefix_from_blacklist(&mut self, prefix: &str) -> Result<()> {
+        ensure!(self.trane.is_some(), "no Trane instance is open");
+
+        self.trane
+            .as_mut()
+            .unwrap()
+            .remove_prefix_from_blacklist(prefix)?;
         self.reset_batch();
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,12 @@ pub(crate) enum BlacklistSubcommands {
         #[clap(help = "The unit to remove from the blacklist")]
         unit_id: Ustr,
     },
+
+    #[clap(about = "Removes all the units that match the given prefix from the blacklist")]
+    RemovePrefix {
+        #[clap(help = "The prefix to remove from the blacklist")]
+        prefix: String,
+    },
 }
 
 /// Contains subcommands used for debugging.
@@ -482,8 +488,14 @@ impl TraneCli {
             }
 
             Subcommands::Blacklist(BlacklistSubcommands::Remove { unit_id }) => {
-                app.whitelist(&unit_id)?;
+                app.remove_from_blacklist(&unit_id)?;
                 println!("Removed {unit_id} from the blacklist");
+                Ok(true)
+            }
+
+            Subcommands::Blacklist(BlacklistSubcommands::RemovePrefix { prefix }) => {
+                app.remove_prefix_from_blacklist(&prefix)?;
+                println!("Removed units matching prefix {prefix} from the blacklist");
                 Ok(true)
             }
 


### PR DESCRIPTION
Implements the function to remove units matching a prefix from the blacklist.