### PR TITLE
Use ubuntu-latest to build x86_64-linux and aarch64-linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
         build: [x86_64-linux, aarch64-linux, aarch64-apple, x86_64-windows]
         include:
         - build: x86_64-linux
-          os: ubuntu-20.04
+          os: ubuntu-latest
           rust: stable
           target: x86_64-unknown-linux-gnu
           cargo_cmd: cargo
         - build: aarch64-linux
-          os: ubuntu-20.04
+          os: ubuntu-latest
           rust: stable
           target: aarch64-unknown-linux-gnu
           cargo_cmd: cross


### PR DESCRIPTION
This PR updates the release workflows for `x86_64-linux` and `aarch64-linux` to use `ubuntu-latest` images instead of `ubuntu-20.04`.  `ubuntu-20.04` is now deprecated and it appears that the [last release](https://github.com/trane-project/trane-cli/actions/runs/14530607721) didn't build all of the binaries because of this.